### PR TITLE
Tunnel in Tunnel Traffic

### DIFF
--- a/fastd-blacklist.json
+++ b/fastd-blacklist.json
@@ -81,5 +81,9 @@
       "pubkey": "d7382ac395820316ef1d3674a525348b3616f0f72e062b756c8421423552b780",
       "comment": "Broadcast Storm #10 MAC: 16:d0:20:ae:04:8c"
     }
+    {
+      "pubkey": "dc5df238d43eeeb0b8a832d4eeeac43197397230643da90b1dda8fdb7a3688e3",
+      "comment": "fastd Tunnel through fastd Tunnel resulting in 70MBit Traffic to nowhere."
+    }
   ]
 }


### PR DESCRIPTION
Only a small amount is forwarded to the Nanostation, but the virtual traffic in bat0 and tap-nodes takes a lot of cpu power.
Wow, increased to 150MBit/sec