### PR TITLE
Update fastd-blacklist.json

### DIFF
--- a/fastd-blacklist.json
+++ b/fastd-blacklist.json
@@ -105,5 +105,13 @@
       "pubkey": "daa49912388dc9b7f2c2efaea3060c922d80398e8a65934671708f3d19930439",
       "comment": "Potential Brige Rheinufer-Aachen, FF-DU-Volker-Herren again"
     }
+    {
+      "pubkey": "a0034a43c559a7181e343196a741dbd6be9b7a9fce1b0a345151bb9ebbafe4d8",
+      "comment": "Potential Brige Moehne biggesee/soest| biggesse fw located soest"
+    }
+    {
+      "pubkey": "185180fc35dccf6335abd8de68cf3f13d4695e2400a53a3e1277295aae4b3736",
+      "comment": "Potential Brige Moehne biggesee/arnsberg| biggesse fw located arnsberg"
+    }
   ]
 }


### PR DESCRIPTION
wrong firmware (biggesee) used in Arnsberg and Soest.
Owner is informed but does not update to the correct firmware.
Moving by auto-updater is not possible (not stable branch)